### PR TITLE
Replace deadlink to grid world example in Sutton book

### DIFF
--- a/gridworld.py
+++ b/gridworld.py
@@ -2,8 +2,8 @@
     This is a simple implementation of the two-agent Gridworld Cliff
     reinforcement learning task.
 
-    Adapted from Example 6.6 at:
-    https://webdocs.cs.ualberta.ca/~sutton/book/ebook/node65.html
+    Adapted from Example 6.6 (page 145) at:
+    http://people.inf.elte.hu/lorincz/Files/RL_2006/SuttonBook.pdf
 
     The board is a 4x12 matrix, with (using Numpy matrix indexing):
         [0, 0] as the start at top-left


### PR DESCRIPTION
It seems the link to the book from the U Alberta website is dead